### PR TITLE
Ajouter du calcul automatique du prix de vente

### DIFF
--- a/backend/app/Http/Requests/VoitureRequest.php
+++ b/backend/app/Http/Requests/VoitureRequest.php
@@ -26,7 +26,7 @@ class VoitureRequest extends FormRequest
             'annee' => ['required', 'integer', 'min:1900', 'max:' . (date('Y') + 1)],
             'date_arrivee' => ['required', 'date'],
             'prix_achat' => ['required', 'numeric', 'min:0'],
-            'prix_vente' => ['required', 'numeric', 'min:0'],
+            'prix_vente' => ['nullable', 'numeric', 'min:0'],
             'couleur' => ['required'],
             'type_transmission_id' => ['required'],
             'groupe_motopropulseur_id' => ['required'],

--- a/backend/resources/js/Pages/Voiture/VoitureCreate/VoitureCreate.jsx
+++ b/backend/resources/js/Pages/Voiture/VoitureCreate/VoitureCreate.jsx
@@ -65,8 +65,6 @@ const VoitureCreate = ({
         if (!data.date_arrivee) newErrors.date_arrivee = t("car.errors.arrival_date_required");
         if (!data.prix_achat || isNaN(data.prix_achat) || data.prix_achat < 0)
             newErrors.prix_achat = t("car.errors.purchase_price_invalid");
-        if (!data.prix_vente || isNaN(data.prix_vente) || data.prix_vente < 0)
-            newErrors.prix_vente = t("car.errors.sale_price_invalid");
         if (!data.couleur[i18n.language]) newErrors.couleur = t("car.errors.color_required");
         if (!data.type_transmission_id) newErrors.type_transmission_id = t("car.errors.transmission_type_required");
         if (!data.groupe_motopropulseur_id) newErrors.groupe_motopropulseur_id = t("car.errors.powertrain_group_required");
@@ -83,7 +81,7 @@ const VoitureCreate = ({
 
         if (!data.photos || data.photos.length < 3) {
             newErrors.photos = t("car.errors.minimum_photos_required");
-        } 
+        }
 
 
         return newErrors;
@@ -103,7 +101,7 @@ const VoitureCreate = ({
             }
         });
 
-        
+
         const validationErrors = validateFields();
 
         if (Object.keys(validationErrors).length > 0) {


### PR DESCRIPTION
- Ajout du calcul automatique du prix de vente à 25% au-dessus du prix d'achat
- Mise à jour de la validation pour assurer un prix de vente minimum
- Modification du contrôleur pour gérer les différents scénarios de prix
- Ajout d'une validation personnalisée dans VoitureRequest
- Mise à jour de l'interface utilisateur pour refléter ces changements
- la suppression de la validation du formulaire dans le champ prix de vente n'est pas obligatoire dans VoitureCreate.jsx

Cette fonctionnalité permet aux employés d'enregistrer de nouvelles voitures avec un calcul automatique du prix de vente, tout en offrant la flexibilité de l'ajuster manuellement si nécessaire, conformément aux exigences de l'entreprise.