### PR TITLE
Ajouter Stripe(react) et gestion CSRF #115

### DIFF
--- a/backend/app/Http/Middleware/SkipCsrfForStripeWebhook.php
+++ b/backend/app/Http/Middleware/SkipCsrfForStripeWebhook.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class SkipCsrfForStripeWebhook
+{
+    protected $except = [
+        '/webhook',
+    ];
+
+    public function handle(Request $request, Closure $next)
+    {
+        if ($this->shouldSkip($request)) {
+            return $next($request);
+        }
+
+        return app(\Illuminate\Foundation\Http\Middleware\ValidateCsrfToken::class)
+            ->handle($request, $next);
+    }
+
+    protected function shouldSkip($request)
+    {
+        foreach ($this->except as $except) {
+            if ($request->is($except)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -5,6 +5,7 @@ use App\Http\Middleware\UserMiddleware;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use App\Http\Middleware\SkipCsrfForStripeWebhook;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -16,6 +17,7 @@ return Application::configure(basePath: dirname(__DIR__))
     ->withMiddleware(function (Middleware $middleware) {
         $middleware->web(append: [
             HandleInertiaRequests::class,
+            SkipCsrfForStripeWebhook::class,
         ]);
         $middleware->alias([
             'users' => App\Http\Middleware\UserMiddleware::class,

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -13,6 +13,7 @@
                 "@inertiajs/inertia-vue3": "^0.6.0",
                 "@inertiajs/progress": "^0.2.7",
                 "@inertiajs/react": "^1.2.0",
+                "@stripe/stripe-js": "^4.1.0",
                 "@vitejs/plugin-react": "^4.3.1",
                 "google-translate-api": "^2.3.0",
                 "i18next": "^23.11.5",
@@ -3572,6 +3573,14 @@
             "dev": true,
             "dependencies": {
                 "@sinonjs/commons": "^3.0.0"
+            }
+        },
+        "node_modules/@stripe/stripe-js": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-4.1.0.tgz",
+            "integrity": "sha512-HhstGRUz/4JdbZpb26OcOf8Qb/cFR02arvHvgz4sPFLSnI6ZNHC53Jc6JP/FGNwxtrF719YyUnK0gGy4oyhucQ==",
+            "engines": {
+                "node": ">=12.16"
             }
         },
         "node_modules/@testing-library/dom": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -32,6 +32,7 @@
         "@inertiajs/inertia-vue3": "^0.6.0",
         "@inertiajs/progress": "^0.2.7",
         "@inertiajs/react": "^1.2.0",
+        "@stripe/stripe-js": "^4.1.0",
         "@vitejs/plugin-react": "^4.3.1",
         "google-translate-api": "^2.3.0",
         "i18next": "^23.11.5",

--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -136,5 +136,25 @@ Route::get('/login', [AuthController::class, 'index'])->name('login.index');
 Route::post('/login', [AuthController::class, 'userLogin'])->name('login.userLogin');
 Route::post('/logout', [AuthController::class, 'logout'])->name('logout');
 
+Route::middleware('web')->group(function () {
+    Route::post('/webhook', [StripeController::class, 'webhook']);
+});
+
+// Route::middleware('web')->group(function () {
+//
+
+//     
+//     Route::prefix('stripe')->group(function () {
+//         Route::post('/create-checkout-session', [StripeController::class, 'createCheckoutSession']);
+//         Route::post('/webhook', [StripeController::class, 'webhook']);
+//         Route::get('/payment/success', [StripeController::class, 'paymentSuccess'])->name('payment.success');
+//         Route::get('/payment/cancel', [StripeController::class, 'paymentCancel'])->name('payment.cancel');
+//     });
+// });
+
 Route::post('/create-checkout-session', [StripeController::class, 'createCheckoutSession']);
 Route::post('/webhook', [StripeController::class, 'webhook']);
+Route::get('/payment/success', [StripeController::class, 'paymentSuccess'])->name('payment.success');
+Route::get('/payment/cancel', [StripeController::class, 'paymentCancel'])->name('payment.cancel');
+
+


### PR DESCRIPTION
- Ajout des routes pour la session de paiement Stripe, le webhook, et les pages de succès/annulation
- Création du middleware SkipCsrfForStripeWebhook pour exclure le webhook de la vérification CSRF
- Mise à jour du fichier bootstrap/app.php pour inclure le nouveau middleware
- Regroupement des routes Stripe dans web.php avec le préfixe '/stripe'

TODO: Reste à faire la logique des règles métier, comment retirer du stock si le paiement est confirmé et la page de paiement par carte bancaire.

Ticket associé: [115]