### PR TITLE
Réparer paiement via Stripe #237

### DIFF
--- a/backend/resources/js/Pages/Cart/CartIndex.jsx
+++ b/backend/resources/js/Pages/Cart/CartIndex.jsx
@@ -1,15 +1,81 @@
 import React, { useState, useEffect } from "react";
-import { Link } from "@inertiajs/react";
 import { useTranslation } from "react-i18next";
 import { loadStripe } from "@stripe/stripe-js";
+import { Elements, CardElement, useStripe, useElements } from "@stripe/react-stripe-js";
+import axios from "axios";
+
+// Config Axios
+axios.defaults.headers.common["X-Requested-With"] = "XMLHttpRequest";
+axios.defaults.withCredentials = true;
 
 // STRIPE KEY PUBLIC
-const stripePromise = loadStripe('pk_test_51PF4mDRu1tx5Etuh3InKoGjspqPg3YrBnWETBSYv1yLB5m4d8R1JK4fM36LioMbzScU4Vy9mJtaennaXRU1gKsat00g5hjVeom');
+const stripePromise = loadStripe(import.meta.env.VITE_STRIPE_KEY);
+
+const CheckoutForm = ({ cartItems, clearCart }) => {
+    const stripe = useStripe();
+    const elements = useElements();
+    const [isProcessing, setIsProcessing] = useState(false);
+    const [errorMessage, setErrorMessage] = useState(null);
+    const { t } = useTranslation();
+
+    const handleSubmit = async (event) => {
+        event.preventDefault();
+        setIsProcessing(true);
+
+        if (!stripe || !elements) {
+            return;
+        }
+
+        const cardElement = elements.getElement(CardElement);
+
+        const { error, paymentMethod } = await stripe.createPaymentMethod({
+            type: 'card',
+            card: cardElement,
+        });
+
+        if (error) {
+            console.error(error);
+            setErrorMessage(error.message);
+            setIsProcessing(false);
+            return;
+        }
+
+        try {
+            const response = await axios.post("/process-payment", {
+                paymentMethod: paymentMethod.id,
+                items: cartItems,
+            });
+
+            if (response.data.success) {
+                clearCart();
+                //TODO message de réussite!
+            } else {
+                setErrorMessage("Payment failed: " + response.data.error);
+            }
+        } catch (error) {
+            console.error("Error during manual checkout:", error);
+            setErrorMessage("An error occurred during checkout. Please try again.");
+        } finally {
+            setIsProcessing(false);
+        }
+    };
+
+    return (
+        <form onSubmit={handleSubmit}>
+            <CardElement />
+            {errorMessage && <div className="error-message">{errorMessage}</div>}
+            <button type="submit" disabled={isProcessing || !stripe}>
+                {isProcessing ? t("cart.processing") : t("cart.checkout")}
+            </button>
+        </form>
+    );
+};
 
 const CartIndex = ({ onClose }) => {
-    const { t, i18n } = useTranslation();
+    const { t } = useTranslation();
     const [cartItems, setCartItems] = useState([]);
     const [isProcessing, setIsProcessing] = useState(false);
+    const [paymentMethod, setPaymentMethod] = useState("checkout");
 
     useEffect(() => {
         const storedCartItems = localStorage.getItem("cartItems");
@@ -36,28 +102,27 @@ const CartIndex = ({ onClose }) => {
 
     const handleCheckout = async () => {
         setIsProcessing(true);
-        const stripe = await stripePromise;
+        try {
+            const stripe = await stripePromise;
+            const response = await axios.post("/create-checkout-session", {
+                items: cartItems,
+            });
 
-        const response = await fetch('/create-checkout-session', {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({ items: cartItems }),
-        });
+            const result = await stripe.redirectToCheckout({
+                sessionId: response.data.id,
+            });
 
-        const session = await response.json();
-
-        const result = await stripe.redirectToCheckout({
-            sessionId: session.id,
-        });
-
-        if (result.error) {
-            console.error(result.error.message);
+            if (result.error) {
+                console.error(result.error.message);
+            }
+        } catch (error) {
+            console.error("Error during checkout:", error);
+        } finally {
+            setIsProcessing(false);
         }
-
-        setIsProcessing(false);
     };
+
+    console.log('Stripe Key:', import.meta.env.VITE_STRIPE_KEY);
 
     return (
         <div className="cart-modal">
@@ -95,13 +160,45 @@ const CartIndex = ({ onClose }) => {
                         <button onClick={clearCart} className="clear-cart">
                             {t("cart.clear")}
                         </button>
-                        <button
-                            onClick={handleCheckout}
-                            className="checkout-button"
-                            disabled={isProcessing}
-                        >
-                            {isProcessing ? t("cart.processing") : t("cart.checkout")}
-                        </button>
+
+                        <div>
+                            <label>
+                                <input
+                                    type="radio"
+                                    value="checkout"
+                                    checked={paymentMethod === "checkout"}
+                                    onChange={() =>
+                                        setPaymentMethod("checkout")
+                                    }
+                                />
+                                {t("cart.useStripeCheckout")}
+                            </label>
+                            <label>
+                                <input
+                                    type="radio"
+                                    value="manual"
+                                    checked={paymentMethod === "manual"}
+                                    onChange={() => setPaymentMethod("manual")}
+                                />
+                                {t("cart.useTestForm")}
+                            </label>
+                        </div>
+
+                        {paymentMethod === "checkout" ? (
+                            <button
+                                onClick={handleCheckout}
+                                className="checkout-button"
+                                disabled={isProcessing}
+                            >
+                                {isProcessing
+                                    ? t("cart.processing")
+                                    : t("cart.checkout")}
+                            </button>
+                        ) : (
+                            <Elements stripe={stripePromise}>
+                                <CheckoutForm cartItems={cartItems} clearCart={clearCart} />
+                            </Elements>
+                        )}
                     </>
                 )}
             </div>

--- a/backend/resources/js/bootstrap.js
+++ b/backend/resources/js/bootstrap.js
@@ -2,3 +2,10 @@ import axios from 'axios';
 window.axios = axios;
 
 window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
+window.axios.defaults.withCredentials = true;
+
+if (document.querySelector('meta[name="csrf-token"]')) {
+    window.axios.defaults.headers.common['X-CSRF-TOKEN'] = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+} else {
+    console.error('CSRF token not found: https://laravel.com/docs/csrf#csrf-x-csrf-token');
+}

--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -156,7 +156,7 @@ Route::middleware('web')->group(function () {
 // Route::middleware('web')->group(function () {
 //
 
-//     
+//
 //     Route::prefix('stripe')->group(function () {
 //         Route::post('/create-checkout-session', [StripeController::class, 'createCheckoutSession']);
 //         Route::post('/webhook', [StripeController::class, 'webhook']);
@@ -169,5 +169,6 @@ Route::post('/create-checkout-session', [StripeController::class, 'createCheckou
 Route::post('/webhook', [StripeController::class, 'webhook']);
 Route::get('/payment/success', [StripeController::class, 'paymentSuccess'])->name('payment.success');
 Route::get('/payment/cancel', [StripeController::class, 'paymentCancel'])->name('payment.cancel');
+Route::post('/process-payment', [StripeController::class, 'processPayment']);
 
 

--- a/backend/vite.config.js
+++ b/backend/vite.config.js
@@ -1,13 +1,19 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import laravel from 'laravel-vite-plugin';
 import react from '@vitejs/plugin-react';
 
-export default defineConfig({
-    plugins: [
-        laravel({
-            input: ['resources/js/app.jsx'],
-            refresh: true,
-        }),
-        react(),
-    ],
+export default defineConfig(({ mode }) => {
+    const env = loadEnv(mode, process.cwd(), '');
+    return {
+        plugins: [
+            laravel({
+                input: ['resources/js/app.jsx'],
+                refresh: true,
+            }),
+            react(),
+        ],
+        define: {
+            'process.env.VITE_STRIPE_KEY': JSON.stringify(env.VITE_STRIPE_KEY),
+        },
+    };
 });


### PR DESCRIPTION
- Ajout du contrôleur StripeController pour gérer les sessions de paiement
- Implémentation du formulaire de paiement dans le composant CartIndex
- Mise à jour des routes pour les endpoints de paiement
- Gestion des erreurs et des réponses pour les requêtes de paiement
- Ajout de la logique de calcul du montant total du panier

Cette mise à jour permet aux utilisateurs de procéder au paiement via Stripe, soit par redirection vers Stripe Checkout, soit via un formulaire de carte de crédit intégré. Le système gère également les webhooks Stripe pour le traitement des paiements réussis.
TIKET [237]