### PR TITLE
Afficher uniquement les voitures disponibles #238

### DIFF
--- a/backend/app/Http/Controllers/VoitureController.php
+++ b/backend/app/Http/Controllers/VoitureController.php
@@ -22,7 +22,11 @@ class VoitureController extends Controller
 {
     public function index()
     {
-        $voitures = Voiture::with('modele')->get();
+        $today = now()->toDateString(); 
+        $voitures = Voiture::with('modele')
+            ->where('date_arrivee', '<=', $today)
+            ->get();
+
         $privilege_id = Auth::check() ? Auth::user()->privileges_id : null;
 
         foreach ($voitures as $voiture) {
@@ -35,6 +39,7 @@ class VoitureController extends Controller
             'privilege_id' => $privilege_id,
         ]);
     }
+
 
 
     public function create(Request $request)
@@ -62,50 +67,50 @@ class VoitureController extends Controller
         $colors = ['White', 'Black', 'Red', 'Blue', 'Green', 'Yellow', 'Silver', 'Grey'];
         $modeles = Modele::pluck('nom_modele')->toArray();
         $constructeurs = Constructeur::pluck('nom_constructeur')->toArray();
-    
+
         if ($request->filled('etat')) {
             $query->where('etat_vehicule', $request->input('etat'));
         }
-    
+
         if ($request->filled('constructeur')) {
             $query->whereHas('modele.constructeur', function ($q) use ($request) {
                 $q->where('nom_constructeur', $request->input('constructeur'));
             });
         }
-    
+
         if ($request->filled('modele')) {
             $query->whereHas('modele', function ($q) use ($request) {
                 $q->where('nom_modele', $request->input('modele'));
             });
         }
-    
+
         if ($request->filled('annee')) {
             $query->where('annee', $request->input('annee'));
         }
-    
+
         if ($request->filled('prix_max')) {
             $query->where('prix_vente', '<=', $request->input('prix_max'));
         }
-    
+
         if ($request->filled('couleur')) {
             $query->whereJsonContains('couleur', $request->input('couleur'));
         }
-    
+
         if ($request->filled('nombre_places')) {
             $query->where('nombre_places', $request->input('nombre_places'));
         }
-    
+
         if ($request->filled('nombre_portes')) {
             $query->where('nombre_portes', $request->input('nombre_portes'));
         }
-    
+
         $voitures = $query->with(['modele.constructeur', 'photos'])->get();
-    
+
         foreach ($voitures as $voiture) {
             $photo = $voiture->photos->first();
             $voiture->photo_url = $photo ? asset(Storage::url($photo->photos)) : null;
         }
-    
+
         return response()->json([
             'voitures' => $voitures,
             'filters' => [
@@ -115,7 +120,7 @@ class VoitureController extends Controller
             ],
         ]);
     }
-    
+
 
     public function store(VoitureRequest $request)
     {
@@ -177,27 +182,27 @@ class VoitureController extends Controller
         ]);
     }
 
-public function update(Request $request, $id)
-{
-    $voiture = Voiture::findOrFail($id);
-    
-    $validated = $request->validate([
-        'modele_id' => 'required|exists:modeles,id_modele',
-        'annee' => 'required|integer',
-        'prix_vente' => 'required|numeric',
-        'couleur' => 'required',
-        'etat_vehicule' => 'required',
-        'nombre_places' => 'required|integer',
-        'nombre_portes' => 'required|integer',
-        'description' => 'required',
-    ]);
+    public function update(Request $request, $id)
+    {
+        $voiture = Voiture::findOrFail($id);
 
-    // Log::info('Données validées:', $validated);
+        $validated = $request->validate([
+            'modele_id' => 'required|exists:modeles,id_modele',
+            'annee' => 'required|integer',
+            'prix_vente' => 'required|numeric',
+            'couleur' => 'required',
+            'etat_vehicule' => 'required',
+            'nombre_places' => 'required|integer',
+            'nombre_portes' => 'required|integer',
+            'description' => 'required',
+        ]);
 
-    $voiture->update($validated);
-    // Log::info('Voiture mise à jour', ['id' => $voiture->id_voiture]);
-    return redirect()->route('voitures.index');
-}
+        // Log::info('Données validées:', $validated);
+
+        $voiture->update($validated);
+        // Log::info('Voiture mise à jour', ['id' => $voiture->id_voiture]);
+        return redirect()->route('voitures.index');
+    }
 
     public function destroy($id)
     {


### PR DESCRIPTION
Ajout d'une clause `where` dans la méthode `index` pour s'assurer que seules les voitures dont la `date_arrivee` est inférieure ou égale à aujourd'hui sont affichées. Cela garantit que seules les voitures disponibles apparaissent dans la liste des voitures.