### PR TITLE
faire une commande apres stripe

### DIFF
--- a/backend/app/Http/Controllers/StripeController.php
+++ b/backend/app/Http/Controllers/StripeController.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
-
+use Illuminate\Support\Facades\Log;
 use Stripe\Stripe;
 use Stripe\Checkout\Session;
 use App\Models\Commande;
@@ -40,6 +40,59 @@ class StripeController extends Controller
         return response()->json(['id' => $session->id]);
     }
 
+    public function createNewOrder(Request $request)
+    {
+        Log::info('Démarrage de createNewOrder', $request->all());
+        try {
+            // Traiter le paiement
+            $paymentResult = $this->processPayment($request);
+            Log::info('Résultat du traitement :', $paymentResult);
+
+            if ($paymentResult['success']) {
+                // Créer une nouvelle commande
+                $order = new Commande();
+                $order->id_utilisateur = auth()->id() ?? 1; // Utiliser 1 si aucun utilisateur n'est authentifié
+                $order->date_commande = now();
+                $order->prix_total = $this->calculateTotalAmount($request->items);
+                $order->status_commande_id = 1;
+                $order->mode_paiement_id = 1;
+                $order->mode_expedition_id = 1;
+                $order->date_paiement = now();
+                $order->commentaires = 'Commande réalisée via Stripe';
+
+                if (!$order->save()) {
+                    throw new \Exception("Échec de l'enregistrement de la commande dans la base de données.");
+                }
+
+                Log::info('Commande créée :', $order->toArray());
+
+                return response()->json([
+                    'success' => true,
+                    'message' => 'Commande créée avec succès',
+                    'order_id' => $order->id_commande,
+                    'clientSecret' => $paymentResult['clientSecret']
+                ]);
+            } else {
+                Log::error('Échec du traitement du paiement :', $paymentResult);
+                return response()->json([
+                    'success' => false,
+                    'message' => 'Échec du traitement du paiement',
+                    'error' => $paymentResult['error']
+                ], 400);
+            }
+        } catch (\Exception $e) {
+            Log::error('Erreur lors de la création de la commande :', [
+                'message' => $e->getMessage(),
+                'trace' => $e->getTraceAsString()
+            ]);
+            return response()->json([
+                'success' => false,
+                'message' => 'Erreur lors de la création de la commande',
+                'error' => $e->getMessage()
+            ], 500);
+        }
+    }
+
     public function webhook(Request $request)
     {
         $payload = $request->getContent();
@@ -70,7 +123,7 @@ class StripeController extends Controller
                 }
                 break;
             default:
-                echo 'Received unknown event type ' . $event->type;
+                echo 'Reçu un type d\'événement inconnu ' . $event->type;
         }
 
         return response()->json(['status' => 'success']);
@@ -78,18 +131,17 @@ class StripeController extends Controller
 
     public function paymentSuccess()
     {
-
         return Inertia::render('PaymentSuccess');
     }
 
     public function paymentCancel()
     {
-
         return Inertia::render('PaymentCancel');
     }
 
     public function processPayment(Request $request)
     {
+        Log::info('Démarrage du traitement de paiement');
         Stripe::setApiKey(env('STRIPE_SECRET'));
 
         try {
@@ -97,16 +149,19 @@ class StripeController extends Controller
                 'amount' => $this->calculateTotalAmount($request->items) * 100,
                 'currency' => 'cad',
                 'payment_method' => $request->paymentMethod,
-                'confirmation_method' => 'manual',
                 'confirm' => true,
                 'return_url' => route('payment.success'),
+                'automatic_payment_methods' => [
+                    'enabled' => true,
+                ],
             ]);
 
-            // TODO: nous pouvons mettre en œuvre les règles commerciales ici ou d'autres détails sur le paiement
+            Log::info('PaymentIntent créé :', ['id' => $paymentIntent->id]);
 
-            return response()->json(['success' => true, 'clientSecret' => $paymentIntent->client_secret]);
+            return ['success' => true, 'clientSecret' => $paymentIntent->client_secret];
         } catch (\Exception $e) {
-            return response()->json(['success' => false, 'error' => $e->getMessage()]);
+            Log::error('Erreur lors du traitement du paiement :', ['message' => $e->getMessage()]);
+            return ['success' => false, 'error' => $e->getMessage()];
         }
     }
 

--- a/backend/app/Models/Commande.php
+++ b/backend/app/Models/Commande.php
@@ -10,6 +10,7 @@ class Commande extends Model
     use HasFactory;
 
     protected $table = 'commandes';
+    public $timestamps = false;
     protected $primaryKey = 'id_commande';
     protected $fillable = [
         'id_utilisateur', 'date_commande', 'prix_total', 'status_commande_id',

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -13,7 +13,7 @@
         "laravel/sanctum": "^4.0",
         "laravel/tinker": "^2.9",
         "spatie/laravel-image-optimizer": "^1.8",
-        "stripe/stripe-php": "^15.2"
+        "stripe/stripe-php": "^15.5"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",

--- a/backend/composer.lock
+++ b/backend/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5bd99eaed0d51891f1fea8bf3d324414",
+    "content-hash": "6705a9e347083029936afa9ffcff6fd0",
     "packages": [
         {
             "name": "barryvdh/laravel-dompdf",
@@ -3870,16 +3870,16 @@
         },
         {
             "name": "stripe/stripe-php",
-            "version": "v15.2.0",
+            "version": "v15.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/stripe/stripe-php.git",
-                "reference": "29a28251d35dba236ad6e860e1927b3f35cc1b2e"
+                "reference": "d20fbbf2557773106c0ec2198b1b16b40f5081bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/stripe/stripe-php/zipball/29a28251d35dba236ad6e860e1927b3f35cc1b2e",
-                "reference": "29a28251d35dba236ad6e860e1927b3f35cc1b2e",
+                "url": "https://api.github.com/repos/stripe/stripe-php/zipball/d20fbbf2557773106c0ec2198b1b16b40f5081bc",
+                "reference": "d20fbbf2557773106c0ec2198b1b16b40f5081bc",
                 "shasum": ""
             },
             "require": {
@@ -3923,9 +3923,9 @@
             ],
             "support": {
                 "issues": "https://github.com/stripe/stripe-php/issues",
-                "source": "https://github.com/stripe/stripe-php/tree/v15.2.0"
+                "source": "https://github.com/stripe/stripe-php/tree/v15.5.0"
             },
-            "time": "2024-07-11T18:46:58+00:00"
+            "time": "2024-08-01T21:25:52+00:00"
         },
         {
             "name": "symfony/clock",

--- a/backend/database/migrations/2024_08_06_143810_add_timestamps_to_commandes_table.php
+++ b/backend/database/migrations/2024_08_06_143810_add_timestamps_to_commandes_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up()
+    {
+        Schema::table('commandes', function (Blueprint $table) {
+            $table->timestamps();
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('commandes', function (Blueprint $table) {
+            $table->dropTimestamps();
+        });
+    }
+};

--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -172,3 +172,4 @@ Route::post('/webhook', [StripeController::class, 'webhook']);
 Route::get('/payment/success', [StripeController::class, 'paymentSuccess'])->name('payment.success');
 Route::get('/payment/cancel', [StripeController::class, 'paymentCancel'])->name('payment.cancel');
 Route::post('/process-payment', [StripeController::class, 'processPayment']);
+Route::post('/api/create-new-order', [StripeController::class, 'createNewOrder']);


### PR DESCRIPTION
Ajout d'un méthode pour simuler le webhook de Stripe

- Création de la méthode simulateWebhook dans StripeController pour faciliter le test des webhooks Stripe en environnement de développement.
- Cette méthode permet de simuler différents événements de Stripe et de vérifier que notre application les gère correctement.
- Ajout des journaux pour faciliter le débogage et la vérification des événements simulés.