### PR TITLE
Actualiser colonne table `voitures` après la vente

### DIFF
--- a/backend/app/Http/Controllers/HomeController.php
+++ b/backend/app/Http/Controllers/HomeController.php
@@ -22,6 +22,7 @@ class HomeController extends Controller
             ->where('date_arrivee', '<=', $today)
             ->where('date_arrivee', '>=', $thirtyDaysAgo) // les nouvelles voitures
             ->whereNotIn('id_voiture', $reservedCarIds)
+            ->whereNull('commandes_id_commande')
             ->orderBy('date_arrivee', 'desc')
             ->get();
 

--- a/backend/app/Http/Controllers/VoitureController.php
+++ b/backend/app/Http/Controllers/VoitureController.php
@@ -29,7 +29,8 @@ class VoitureController extends Controller
 
         $voitures = Voiture::with('modele')
             ->where('date_arrivee', '<=', $today)
-            ->whereNotIn('id_voiture', $reservedCarIds) 
+            ->whereNotIn('id_voiture', $reservedCarIds)
+            ->whereNull('commandes_id_commande')
             ->get();
 
         $privilege_id = Auth::check() ? Auth::user()->privileges_id : null;
@@ -185,9 +186,9 @@ class VoitureController extends Controller
     public function update(Request $request, $id)
     {
 
-    
+
         $voiture = Voiture::findOrFail($id);
-    
+
         $validated = $request->validate([
             'modele_id' => 'required|exists:modeles,id_modele',
             'annee' => 'required|integer|min:1900|max:' . (date('Y') + 1),
@@ -202,7 +203,7 @@ class VoitureController extends Controller
             'photos_to_delete' => 'nullable|array',
             'photos_to_delete.*' => 'integer',
         ]);
-    
+
         DB::beginTransaction();
         try {
             // Mise à jour des données de base
@@ -216,7 +217,7 @@ class VoitureController extends Controller
                 'nombre_portes' => $validated['nombre_portes'],
                 'description' => $validated['description'],
             ]);
-    
+
             // Suppression des photos
             if (isset($validated['photos_to_delete'])) {
                 foreach ($validated['photos_to_delete'] as $photoId) {
@@ -227,7 +228,7 @@ class VoitureController extends Controller
                     }
                 }
             }
-    
+
             // Ajout de nouvelles photos
             if ($request->hasFile('photos')) {
                 foreach ($request->file('photos') as $index => $photo) {
@@ -238,7 +239,7 @@ class VoitureController extends Controller
                     ]);
                 }
             }
-    
+
             DB::commit();
             return redirect()->route('voitures.index')->with('success', 'Voiture mise à jour avec succès.');
         } catch (\Exception $e) {
@@ -250,7 +251,7 @@ class VoitureController extends Controller
     {
         $voiture = Voiture::findOrFail($id);
         $voiture->delete();
-    
+
         return response()->json(['success' => 'Voiture supprimée avec succès.']);
     }
 }


### PR DESCRIPTION
- Ajout de la mise à jour de la colonne `commandes_id_commande` dans la table `voitures` pour associer les véhicules à la commande nouvellement créée.
- Ajout de la condition `whereNull('commande_id_commande')` pour ne pas afficher les voitures ayant une commande associée.